### PR TITLE
Fix the name conflict of kprobe and kretprobe

### DIFF
--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -520,8 +520,8 @@ static int32_t load_tracepoint(scap_t* handle, const char *event, struct bpf_ins
 
 		if(memcmp(event, "filler/", sizeof("filler/") - 1) != 0)
 		{
-			snprintf(buf, sizeof(buf), "%c:%s %s",
-				 is_kprobe ? 'p' : 'r', event, event);
+			snprintf(buf, sizeof(buf), "%s%s %s",
+				 is_kprobe ? "p:p_" : "r:r_", event, event);
 			err = write_kprobe_events(buf);
 			if(err < 0 && errno != 17)
 			{


### PR DESCRIPTION
Signed-off-by: zjuzzb <21921231@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind bug

**Any specific area of the project related to this PR?**

> /area libscap

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Now libscap will load kprobe and kretprobe with the same event name. The PR fixes it.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #https://github.com/Kindling-project/kindling/issues/110

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
