### PR TITLE
suppress thread by matching comm

### DIFF
--- a/userspace/libscap/scap_procs.c
+++ b/userspace/libscap/scap_procs.c
@@ -1604,7 +1604,7 @@ int32_t scap_check_suppressed(scap_t *handle, scap_evt *pevent, bool *suppressed
 
 		if((res = scap_update_suppressed(handle,
 						 comm,
-						 pevent->tid, *ptid,
+						 pevent->tid, 0,
 						 suppressed)) != SCAP_SUCCESS)
 		{
 			// scap_update_suppressed already set handle->m_lasterr on error.


### PR DESCRIPTION
https://github.com/Kindling-project/kindling/issues/146 In this issue, kindling-probe cannot get events because the application threads are cloned by containerd-shim which is suppressed by kindling-probe. We just want to suppress thread by matching comm,  setting ptid to 0 will skip the ptid checking and force the comm matching.