### PR TITLE
Log instead of throw exception when detecting cpu config change

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4906,6 +4906,8 @@ void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)
 {
 	if(m_inspector->is_live())
 	{
+		printf("CPU %s configuration change detected. Aborting.",
+		       evt->get_param_value_str("cpu").c_str());
 		throw sinsp_exception("CPU " + evt->get_param_value_str("cpu") +
 				      " configuration change detected. Aborting.");
 	}

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4906,7 +4906,7 @@ void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)
 {
 	if(m_inspector->is_live())
 	{
-		printf("CPU %s configuration change detected. Aborting.",
+		printf("CPU %s configuration change detected.\n",
 		       evt->get_param_value_str("cpu").c_str());
 //		throw sinsp_exception("CPU " + evt->get_param_value_str("cpu") +
 //				      " configuration change detected. Aborting.");

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4909,7 +4909,7 @@ void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)
 		printf("CPU %s configuration change detected. Aborting.",
 		       evt->get_param_value_str("cpu").c_str());
 //		throw sinsp_exception("CPU " + evt->get_param_value_str("cpu") +
-				      " configuration change detected. Aborting.");
+//				      " configuration change detected. Aborting.");
 	}
 }
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -4908,7 +4908,7 @@ void sinsp_parser::parse_cpu_hotplug_enter(sinsp_evt *evt)
 	{
 		printf("CPU %s configuration change detected. Aborting.",
 		       evt->get_param_value_str("cpu").c_str());
-		throw sinsp_exception("CPU " + evt->get_param_value_str("cpu") +
+//		throw sinsp_exception("CPU " + evt->get_param_value_str("cpu") +
 				      " configuration change detected. Aborting.");
 	}
 }


### PR DESCRIPTION
The related issue is https://github.com/Kindling-project/kindling/issues/41.

When the CPU configuration change is detected, there is an exception thrown which will terminate the probe. This PR suppresses this exception which will prevent the agent from terminating. We have confirmed that this will not make a great impact on the events, so we could adopt this as a temporary solution. We will dig into the codes later to resolve the root cause.